### PR TITLE
Make affixes only display with a new debug-mode (I)nspect.

### DIFF
--- a/src/object/obj-info.c
+++ b/src/object/obj-info.c
@@ -1043,6 +1043,7 @@ static void describe_flavor_text(textblock *tb, const object_type *o_ptr,
 	int i, count = 0;
 	bool ego = mode & OINFO_EGO;
 	bool subj = mode & OINFO_SUBJ;
+	bool debug = mode & OINFO_DEBUG;
 
 	/* Display the known artifact description */
 	if (!OPT(birth_randarts) && o_ptr->artifact &&
@@ -1077,17 +1078,19 @@ static void describe_flavor_text(textblock *tb, const object_type *o_ptr,
 	}
 
 	/* List the affixes on the item */
-	for (i = 0; i < MAX_AFFIXES && o_ptr->affix[i]; i++)
-		if (object_affix_is_known(o_ptr, o_ptr->affix[i]->eidx)) {
-			if (count == 0)
-				textblock_append(tb, "This item's known properties are: ");
-			else
-				textblock_append(tb, ", ");
-			textblock_append(tb, "%s", o_ptr->affix[i]->name);
-			count++;
-		}
-	if (count)
-		textblock_append(tb, ".\n\n");
+	if (debug) {
+		for (i = 0; i < MAX_AFFIXES && o_ptr->affix[i]; i++)
+			if (object_affix_is_known(o_ptr, o_ptr->affix[i]->eidx)) {
+				if (count == 0)
+					textblock_append(tb, "This item's known properties are: ");
+				else
+					textblock_append(tb, ", ");
+				textblock_append(tb, "%s", o_ptr->affix[i]->name);
+				count++;
+			}
+		if (count)
+			textblock_append(tb, ".\n\n");
+	}
 
 	if (!ego && subj && o_ptr->origin != ORIGIN_STORE) {
 		/* List the item's known runes */
@@ -1171,6 +1174,7 @@ static textblock *object_info_out(const object_type *o_ptr, oinfo_detail_t mode)
 	bool terse = mode & OINFO_TERSE;
 	bool subjective = mode & OINFO_SUBJ;
 	bool ego = mode & OINFO_EGO;
+	bool debug = mode & OINFO_DEBUG;
 
 	textblock *tb = textblock_new();
 

--- a/src/object/object.h
+++ b/src/object/object.h
@@ -133,7 +133,8 @@ typedef enum {
 	OINFO_SUBJ   = 0x02, 	/* Describe object from the character's POV */
 	OINFO_FULL   = 0x04, 	/* Treat object as if fully IDd */
 	OINFO_DUMMY  = 0x08, 	/* Object does not exist (e.g. knowledge menu) */
-	OINFO_EGO    = 0x10  	/* Describe ego random powers */
+	OINFO_EGO    = 0x10,  	/* Describe ego random powers */
+	OINFO_DEBUG  = 0x20		/* Describe various debug information */
 } oinfo_detail_t;
 
 /* Modes for stacking by object_similar() */

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -1635,6 +1635,38 @@ static void do_cmd_wiz_advance(void)
 
 }
 
+/**
+ * Examine an item, including debug info.
+ * Largely copied from textui_obj_examine.
+ */
+void do_cmd_wiz_examine(void)
+{
+	char header[120];
+
+	textblock *tb;
+	region area = { 0, 0, 0, 0 };
+
+	object_type *o_ptr;
+	int item;
+
+	/* Select item */
+	if (!get_item(&item, "Examine which item?", "You have nothing to examine.",
+			CMD_NULL, (USE_EQUIP | USE_INVEN | USE_FLOOR | IS_HARMLESS)))
+		return;
+
+	/* Track object for object recall */
+	track_object(item);
+
+	/* Display info */
+	o_ptr = object_from_item_idx(item);
+	tb = object_info(o_ptr, OINFO_DEBUG);
+	object_desc(header, sizeof(header), o_ptr,
+			ODESC_ARTICLE | ODESC_FULL | ODESC_CAPITAL);
+
+	textui_textblock_show(tb, area, header);
+	textblock_free(tb);
+}
+
 /*
  * Ask for and parse a "debug command"
  *
@@ -1806,6 +1838,13 @@ void do_cmd_debug(void)
 		case 'i':
 		{
 			(void)ident_spell();
+			break;
+		}
+
+		/* Examine */
+		case 'I':
+		{
+			do_cmd_wiz_examine();
 			break;
 		}
 


### PR DESCRIPTION
It should now be simple to put any debug information you want in an item's description. Just use Ctrl-a + I to see it.
